### PR TITLE
Add reflection feature and final quote

### DIFF
--- a/main.rs
+++ b/main.rs
@@ -1,8 +1,29 @@
 #!/usr/bin/env rust
 
 use std::time::{SystemTime, UNIX_EPOCH};
+use std::fs::OpenOptions;
+use std::io::{self, Write};
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.contains(&"--refection".to_string()) {
+        println!("How are you feeling today?");
+        let mut answer = String::new();
+        io::stdin()
+            .read_line(&mut answer)
+            .expect("Failed to read line");
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("refection.txt")
+            .expect("Unable to open file");
+        if let Err(e) = writeln!(file, "{}", answer.trim()) {
+            eprintln!("Could not write to file: {}", e);
+        } else {
+            println!("Reflection saved. Here's a quote for you:");
+        }
+    }
+
     let stoic_quotes = vec![
         "The mind is everything; what you think, you become. - Buddha",
         "Simplicity is the ultimate sophistication. - Leonardo da Vinci",
@@ -13,6 +34,7 @@ fn main() {
         "The only true wisdom is in knowing you know nothing. - Socrates",
         "The mind that is anxious about future events is miserable. - Seneca",
         "Don't explain your philosophy. Embody it. - Epictetus",
+        "He who is brave is free. - Seneca",
     ];
 
     let now = SystemTime::now()


### PR DESCRIPTION
## Summary
- add `--refection` option for saving mood entries
- store user reflections in `refection.txt`
- keep Stoic sayings list with Seneca's bravery quote
- check for `--refection` using `args.contains`

## Testing
- `rustc main.rs -o stoic`
- `./stoic`
- `./stoic --refection <<'EOF'
Excited
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6865132871188327923722c29a6cf3c3